### PR TITLE
Jade/mod2 mutable salad

### DIFF
--- a/module2/mutable_fruit_salad/Cargo.toml
+++ b/module2/mutable_fruit_salad/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mutable_fruit_salad"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 [dependencies]

--- a/module2/mutable_fruit_salad/Cargo.toml
+++ b/module2/mutable_fruit_salad/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "mutable_fruit_salad"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+clap = { version = "4.3.4", features = ["derive"] }
+csv = "1.1.6"
+rand = "0.8.5"
+
+[lib]
+name = "fruit_salad_maker"
+path = "src/lib.rs"

--- a/module2/mutable_fruit_salad/Makefile
+++ b/module2/mutable_fruit_salad/Makefile
@@ -1,0 +1,38 @@
+SHELL := /bin/bash
+.PHONY: help
+
+help:
+	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
+
+clean: ## Clean the project using cargo
+	cargo clean
+
+build: ## Build the project using cargo
+	cargo build
+
+run: ## Run the project using cargo
+	cargo run
+
+test: ## Run the tests using cargo
+	cargo test
+
+lint: ## Run the linter using cargo
+	@rustup component add clippy 2> /dev/null
+	cargo clippy
+
+format: ## Format the code using cargo
+	@rustup component add rustfmt 2> /dev/null
+	cargo fmt
+
+release:
+	cargo build --release
+
+all: format lint test run
+
+bump: ## Bump the version of the project
+	@echo "Current version is $(shell cargo pkgid | cut -d# -f2)"
+	@read -p "Enter the new version: " version; \
+	updated_version=$$(cargo pkgid | cut -d# -f2 | sed "s/$(shell cargo pkgid | cut -d# -f2)/$$version/"); \
+	sed -i -E "s/^version = .*/version = \"$$updated_version\"/" Cargo.toml
+	@echo "Version bumped to $$(cargo pkgid | cut -d# -f2)"
+	rm Cargo.toml-e

--- a/module2/mutable_fruit_salad/fruits.csv
+++ b/module2/mutable_fruit_salad/fruits.csv
@@ -1,0 +1,1 @@
+maçã, banana, laranja, morango, abacaxi, manga, pêssego, limão, melancia, uva

--- a/module2/mutable_fruit_salad/src/lib.rs
+++ b/module2/mutable_fruit_salad/src/lib.rs
@@ -1,0 +1,25 @@
+/*
+This code defines a function called create_fruit_salad 
+that takes a mutable vector of strings as input and returns 
+a new vector of strings that contains the same elements as the input vector, 
+but in a random order.
+*/
+
+use rand::seq::SliceRandom;
+use rand::thread_rng;
+
+pub fn create_fruit_salad(mut fruits: Vec<String>) -> Vec<String> {
+    let mut rng = thread_rng();
+    fruits.shuffle(&mut rng);
+
+    fruits
+}
+
+pub fn fruit_salad_vec() -> Vec<&'static str> {
+    vec!["apple", "banana", "cherry", "dates", "elderberries"]
+}
+
+pub fn check_and_add_fruit(mut fruit_salad: Vec<&str>) -> Result<Vec<&str>, &'static str> {
+    fruit_salad.push("figs");
+    Ok(fruit_salad)
+}

--- a/module2/mutable_fruit_salad/src/lib.rs
+++ b/module2/mutable_fruit_salad/src/lib.rs
@@ -1,7 +1,7 @@
 /*
-This code defines a function called create_fruit_salad 
-that takes a mutable vector of strings as input and returns 
-a new vector of strings that contains the same elements as the input vector, 
+This code defines a function called create_fruit_salad
+that takes a mutable vector of strings as input and returns
+a new vector of strings that contains the same elements as the input vector,
 but in a random order.
 */
 
@@ -15,6 +15,15 @@ pub fn create_fruit_salad(mut fruits: Vec<String>) -> Vec<String> {
     fruits
 }
 
+pub fn display_fruit_salad(fruits: Vec<String>) {
+    println!("Your fruit salad contains:");
+    for fruit in fruits {
+        println!("{}", fruit);
+    }
+}
+
+// Examples of mutability/immutability in Rust
+
 pub fn fruit_salad_vec() -> Vec<&'static str> {
     vec!["apple", "banana", "cherry", "dates", "elderberries"]
 }
@@ -22,4 +31,32 @@ pub fn fruit_salad_vec() -> Vec<&'static str> {
 pub fn check_and_add_fruit(mut fruit_salad: Vec<&str>) -> Result<Vec<&str>, &'static str> {
     fruit_salad.push("figs");
     Ok(fruit_salad)
+}
+
+pub fn mutability_examples() {
+    // immutable vector
+    let fruit_salad_immutable = fruit_salad_vec();
+    println!(
+        "Original immutable fruit salad: {:?}",
+        fruit_salad_immutable
+    );
+
+    // To mutate the vector, we need to declare it as mutable:
+    let mut fruit_salad_mutable = fruit_salad_vec();
+    fruit_salad_mutable.push("figs");
+    println!("Modified mutable fruit salad: {:?}", fruit_salad_mutable);
+
+    // Clone immutable to mutable and add figs by changing ownership.
+    let result = check_and_add_fruit(fruit_salad_immutable.clone());
+    match result {
+        Ok(mutated_fruit_salad) => println!(
+            "Added figs to the cloned fruit salad: {:?}",
+            mutated_fruit_salad
+        ),
+        Err(err) => println!("Error: {}", err),
+    }
+    println!(
+        "Original immutable fruit salad: {:?}",
+        fruit_salad_immutable
+    );
 }

--- a/module2/mutable_fruit_salad/src/main.rs
+++ b/module2/mutable_fruit_salad/src/main.rs
@@ -1,0 +1,78 @@
+/*
+Usage:  
+
+cargo run -- fruits.csv
+or
+cargo run -- --fruits "apple, pear"
+
+ */
+
+ use clap::Parser;
+ use fruit_salad_maker::{check_and_add_fruit, create_fruit_salad, fruit_salad_vec};
+ 
+ #[derive(Parser)]
+ #[clap(
+     version = "1.0",
+     author = "Your Name <your.email@example.com>",
+     about = "Make a Fruit Salad"
+ )]
+ struct Opts {
+     /// Fruits input as a string of comma separated values
+     #[clap(short, long)]
+     fruits: Option<String>,
+     csvfile: Option<String>,
+ }
+ 
+ // Function that converts a csv file to a vector of strings
+ fn csv_to_vec(csv: &str) -> Vec<String> {
+     csv.split(',')
+         .map(|s| s.trim().to_string())
+         .collect()
+ }
+ fn display_fruit_salad(fruits: Vec<String>) {
+     println!("Your fruit salad contains:");
+     for fruit in fruits {
+         println!("{}", fruit);
+     }
+ }
+ 
+ fn main() {
+    // immutable vector
+    let fruit_salad_immutable = fruit_salad_vec();
+    println!("Original immutable fruit salad: {:?}", fruit_salad_immutable);
+
+    // To mutate the vector, we need to declare it as mutable:
+    let mut fruit_salad_mutable = fruit_salad_vec();
+    fruit_salad_mutable.push("figs");
+    println!("Modified mutable fruit salad: {:?}", fruit_salad_mutable);
+ 
+    // Clone immutable to mutable and add figs by changing ownership.
+    let result = check_and_add_fruit(fruit_salad_immutable.clone());
+    match result {
+        Ok(mutated_fruit_salad) => println!("Added figs to the cloned fruit salad: {:?}", mutated_fruit_salad),
+        Err(err) => println!("Error: {}", err),
+    }
+    println!("Original immutable fruit salad: {:?}", fruit_salad_immutable);
+
+    let opts: Opts = Opts::parse();
+ 
+    // Use fruits from CSV file or command-line input
+    let fruit_list = match opts.csvfile {
+        Some(filename) => {
+            let fruits = std::fs::read_to_string(filename)
+                .expect("Could not read file");
+            csv_to_vec(&fruits)
+        },
+        None => {
+            opts.fruits.unwrap_or_default()
+                .split(',')
+                .map(|s| s.trim().to_string())
+                .collect()
+        },
+    };
+
+    // display fruit salad
+    let fruit_salad = create_fruit_salad(fruit_list);
+    display_fruit_salad(fruit_salad);
+
+}

--- a/module2/mutable_fruit_salad/src/main.rs
+++ b/module2/mutable_fruit_salad/src/main.rs
@@ -1,5 +1,5 @@
 /*
-Usage:  
+Usage:
 
 cargo run -- fruits.csv
 or
@@ -7,72 +7,48 @@ cargo run -- --fruits "apple, pear"
 
  */
 
- use clap::Parser;
- use fruit_salad_maker::{check_and_add_fruit, create_fruit_salad, fruit_salad_vec};
- 
- #[derive(Parser)]
- #[clap(
-     version = "1.0",
-     author = "Your Name <your.email@example.com>",
-     about = "Make a Fruit Salad"
- )]
- struct Opts {
-     /// Fruits input as a string of comma separated values
-     #[clap(short, long)]
-     fruits: Option<String>,
-     csvfile: Option<String>,
- }
- 
- // Function that converts a csv file to a vector of strings
- fn csv_to_vec(csv: &str) -> Vec<String> {
-     csv.split(',')
-         .map(|s| s.trim().to_string())
-         .collect()
- }
- fn display_fruit_salad(fruits: Vec<String>) {
-     println!("Your fruit salad contains:");
-     for fruit in fruits {
-         println!("{}", fruit);
-     }
- }
- 
- fn main() {
-    // immutable vector
-    let fruit_salad_immutable = fruit_salad_vec();
-    println!("Original immutable fruit salad: {:?}", fruit_salad_immutable);
+use clap::Parser;
+use fruit_salad_maker::{create_fruit_salad, display_fruit_salad, mutability_examples};
 
-    // To mutate the vector, we need to declare it as mutable:
-    let mut fruit_salad_mutable = fruit_salad_vec();
-    fruit_salad_mutable.push("figs");
-    println!("Modified mutable fruit salad: {:?}", fruit_salad_mutable);
- 
-    // Clone immutable to mutable and add figs by changing ownership.
-    let result = check_and_add_fruit(fruit_salad_immutable.clone());
-    match result {
-        Ok(mutated_fruit_salad) => println!("Added figs to the cloned fruit salad: {:?}", mutated_fruit_salad),
-        Err(err) => println!("Error: {}", err),
-    }
-    println!("Original immutable fruit salad: {:?}", fruit_salad_immutable);
+#[derive(Parser)]
+#[clap(
+    version = "1.0",
+    author = "Your Name <your.email@example.com>",
+    about = "Make a Fruit Salad"
+)]
+struct Opts {
+    /// Fruits input as a string of comma separated values
+    #[clap(short, long)]
+    fruits: Option<String>,
+    csvfile: Option<String>,
+}
+
+// Function that converts a csv file to a vector of strings
+fn csv_to_vec(csv: &str) -> Vec<String> {
+    csv.split(',').map(|s| s.trim().to_string()).collect()
+}
+
+fn main() {
+    // run mutability examples
+    mutability_examples();
 
     let opts: Opts = Opts::parse();
- 
+
     // Use fruits from CSV file or command-line input
     let fruit_list = match opts.csvfile {
         Some(filename) => {
-            let fruits = std::fs::read_to_string(filename)
-                .expect("Could not read file");
+            let fruits = std::fs::read_to_string(filename).expect("Could not read file");
             csv_to_vec(&fruits)
-        },
-        None => {
-            opts.fruits.unwrap_or_default()
-                .split(',')
-                .map(|s| s.trim().to_string())
-                .collect()
-        },
+        }
+        None => opts
+            .fruits
+            .unwrap_or_default()
+            .split(',')
+            .map(|s| s.trim().to_string())
+            .collect(),
     };
 
     // display fruit salad
     let fruit_salad = create_fruit_salad(fruit_list);
     display_fruit_salad(fruit_salad);
-
 }


### PR DESCRIPTION
This pull request introduces a new Rust project called `mutable_fruit_salad`, which includes several new files and functionalities. The most important changes involve setting up the project structure, adding dependencies, creating a Makefile for build automation, defining core functions for fruit salad manipulation, and implementing command-line interface (CLI) functionality.

Project setup and dependencies:

* [`module2/mutable_fruit_salad/Cargo.toml`](diffhunk://#diff-e13cb43c0494fea8aa8292216fe4d6aa0837ae0f4036661678d00da2b7f8449eR1-R13): Added the project metadata, dependencies (`clap`, `csv`, `rand`), and library configuration.

Build automation:

* [`module2/mutable_fruit_salad/Makefile`](diffhunk://#diff-45c80c7d5109e8c4cb1ceefa1d4ddc603f8a7d42e56ba1e616da32255cff82e1R1-R38): Introduced a Makefile with targets for common tasks like building, running, testing, linting, formatting, and version bumping using cargo.

Core functionality:

* [`module2/mutable_fruit_salad/src/lib.rs`](diffhunk://#diff-30142e5f7d497af434419939fa952025d5e007f5950f085e3164ad842f63f95cR1-R62): Defined functions for creating and displaying a fruit salad, as well as examples of mutability and immutability in Rust.

Command-line interface:

* [`module2/mutable_fruit_salad/src/main.rs`](diffhunk://#diff-9f39a00cdb2cf0c4b58e1145f910010b76a68e27b181d1553d910fb6fe867349R1-R54): Implemented CLI functionality using the `clap` crate, allowing users to input fruits via a CSV file or command-line arguments, and display the resulting fruit salad.

Data file:

* [`module2/mutable_fruit_salad/fruits.csv`](diffhunk://#diff-daf4d6064b9121a269ba08a7870955505f8a9759749a974288e404d45ad99374R1): Added a sample CSV file containing a list of fruits.